### PR TITLE
Shorter regular expression for dash characters

### DIFF
--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -46,7 +46,7 @@ public class Slugify {
 				.replaceAll("[^\\p{ASCII}]", "")
 				.replaceAll("[^\\w+]", "-")
 				.replaceAll("\\s+", "-")
-				.replaceAll("-+", "-")
+				.replaceAll("--+", "-")
 				.replaceAll("^-", "")
 				.replaceAll("-$", "");
 

--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -46,7 +46,7 @@ public class Slugify {
 				.replaceAll("[^\\p{ASCII}]", "")
 				.replaceAll("[^\\w+]", "-")
 				.replaceAll("\\s+", "-")
-				.replaceAll("[-]+", "-")
+				.replaceAll("-+", "-")
 				.replaceAll("^-", "")
 				.replaceAll("-$", "");
 


### PR DESCRIPTION
No need no wrap dash character with square brackets in regular expression `[-]+`.