### PR TITLE
Use .toString() instead of string casting

### DIFF
--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -39,7 +39,7 @@ public class Slugify {
 		}
 
 		for (Entry<Object, Object> e : replacements.entrySet()) {
-			input = input.replace((String) e.getKey(), (String) e.getValue());
+			input = input.replace(e.getKey().toString(), e.getValue().toString());
 		}
 
 		input = Normalizer.normalize(input, Normalizer.Form.NFD)


### PR DESCRIPTION
Replace `(String) foo` by `foo.toString()` to get nicer code.