### PR TITLE
Testing Against Multiple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6


### PR DESCRIPTION
Project configuration file `pom.xml` uses Java version 1.6. [Travis CI](https://docs.travis-ci.com/user/languages/java#Testing-Against-Multiple-JDKs) uses JDK 7 by default.