### PR TITLE
Normalization Form - Use NFKD insted of NFD

### DIFF
--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -52,7 +52,7 @@ public class Slugify {
 	}
 	
 	protected String normalize(String input) {
-	    input = Normalizer.normalize(input, Normalizer.Form.NFD)
+	    input = Normalizer.normalize(input, Normalizer.Form.NFKD)
 	    		.replaceAll("[^\\p{ASCII}]+", "")
 	    		.replaceAll("(?:[^\\w+]|\\s)+", "-")
 	    		.replaceAll("^-|-$", "");

--- a/core/src/test/java/com/github/slugify/SlugifyTest.java
+++ b/core/src/test/java/com/github/slugify/SlugifyTest.java
@@ -54,7 +54,7 @@ public class SlugifyTest {
 				+ "èéêëìíîïðñòóôõö÷øùúûüýþÿ"
                                 + "ĄĆĘŁŃÓŚŹŻąćęłńóśźż";
 
-		String expected = "szszyaaaaaeaceeeeiiiinoooooeuuuueyssaaaaaeaceeeeiiiinoooooeuuuueyyacelnoszzacelnoszz";
+		String expected = "sz-tmszy-a-23-1o141234aaaaaeaceeeeiiiinoooooeuuuueyssaaaaaeaceeeeiiiinoooooeuuuueyyacelnoszzacelnoszz";
 
 		assertEquals(expected, slg1.slugify(s));
 	}


### PR DESCRIPTION
NFKD does a compatibility decomposition, followed by canonical composition. More non-ASCII characters can be decomposed by this form.