### PR TITLE
Optimizing number of calls to pattern.compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+  - oraclejdk9
+  - openjdk7


### PR DESCRIPTION
Call to 'input.replace' internally creates new Pattern every-time. In my case, I was invoking slugify() 2million times, and this single line would use 1.25gb of memory in TLAB.
This is because in ```builtInReplacements```, there's an iteration over the entire list of replacements, and then a regex-match is done for each of these characters, regardless of whether ```input``` contains them or not.
After this refactoring, the iteration is instead on the ```input```, and a lookup is done in the map of ```replacements``` to check, if it needs to be replaced. This is way, the ```builtInReplacements``` avoids any regex-match and also, the complexity reduces significantly. Post this change, the memory allocated in TLAB was barely 40MB.