### PR TITLE
Make normalization behavior consistent for both - and _ separators

### DIFF
--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -18,7 +18,8 @@ public class Slugify {
 	private final static String EMPTY = "";
 
 	private final static Pattern PATTERN_NORMALIZE_NON_ASCII = Pattern.compile("[^\\p{ASCII}]+");
-	private final static Pattern PATTERN_NORMALIZE_SEPARATOR = Pattern.compile("[\\W\\s+]+");
+	private final static Pattern PATTERN_NORMALIZE_HYPHEN_SEPARATOR = Pattern.compile("[\\W\\s+]+");
+	private final static Pattern PATTERN_NORMALIZE_UNDERSCORE_SEPARATOR = Pattern.compile("[[^a-zA-Z0-9\\-]\\s+]+");
 	private final static Pattern PATTERN_NORMALIZE_TRIM_DASH = Pattern.compile("^-|-$");
 
 	private static final Transliterator TRANSLITERATOR = Transliterator.getInstance(ASCII);
@@ -160,7 +161,8 @@ public class Slugify {
 
 	private String matchAndReplace(final String input) {
 		String text = PATTERN_NORMALIZE_NON_ASCII.matcher(input).replaceAll(EMPTY);
-		text = PATTERN_NORMALIZE_SEPARATOR.matcher(text).replaceAll(underscoreSeparator ? "_" : "-");
+		text = underscoreSeparator ? PATTERN_NORMALIZE_UNDERSCORE_SEPARATOR.matcher(text).replaceAll("_") :
+				PATTERN_NORMALIZE_HYPHEN_SEPARATOR.matcher(text).replaceAll("-");
 		text = PATTERN_NORMALIZE_TRIM_DASH.matcher(text).replaceAll(EMPTY);
 
 		return text;

--- a/core/src/test/java/com/github/slugify/SlugifyTest.java
+++ b/core/src/test/java/com/github/slugify/SlugifyTest.java
@@ -232,4 +232,30 @@ public class SlugifyTest {
 		// then
 		assertEquals("jian-kang-guan-li", result);
 	}
+
+	@Test
+	public void doesTrimRepeatedHyphensToSingleHyphenWitHyphenSeparator() {
+		//given
+		String string = "a---b";
+
+		//when
+		String result = new Slugify().slugify(string);
+
+		//then
+		assertEquals("a-b", result);
+	}
+
+
+	@Test
+	public void doesNotTrimRepeatedUnderscoresToSingleUnderscoreWithUnderscoreSeparator() {
+		//given
+		String string = "a___b";
+
+		//when
+		String result = new Slugify().withUnderscoreSeparator(true).slugify(string);
+
+		//then
+		assertEquals("a___b", result);
+	}
+
 }

--- a/core/src/test/java/com/github/slugify/SlugifyTest.java
+++ b/core/src/test/java/com/github/slugify/SlugifyTest.java
@@ -234,28 +234,26 @@ public class SlugifyTest {
 	}
 
 	@Test
-	public void doesTrimRepeatedHyphensToSingleHyphenWitHyphenSeparator() {
+	public void shouldNormalizeRepeatedHyphensToSingleHyphenWithHyphenSeparator() {
 		//given
-		String string = "a---b";
+		String string = "a---b___c";
 
 		//when
 		String result = new Slugify().slugify(string);
 
 		//then
-		assertEquals("a-b", result);
+		assertEquals("a-b___c", result);
 	}
 
-
 	@Test
-	public void doesNotTrimRepeatedUnderscoresToSingleUnderscoreWithUnderscoreSeparator() {
+	public void shouldNormalizeRepeatedUnderscoresToSingleUnderscoreWithUnderscoreSeparator() {
 		//given
-		String string = "a___b";
+		String string = "a---b___c";
 
 		//when
 		String result = new Slugify().withUnderscoreSeparator(true).slugify(string);
 
 		//then
-		assertEquals("a___b", result);
+		assertEquals("a---b_c", result);
 	}
-
 }


### PR DESCRIPTION
# Current behavior
Regardless of whether - or _ is the separator, multiple consecutive instances of - are normalized to one -; whereas multiple consecutive instances of _ are left intact.
The reason for this is the regex used in PATTERN_NORMALIZE_SEPARATOR: "[\\W\\s+]+"
The \\W excludes _ but not -. (See https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html)

# The fix
I have created an additional regex Pattern, which is suitable to use with _ separator. I use the appropriate Pattern, depending on the separator (_ or -).

I've added two tests to illustrate the behavior. All the existing tests are unchanged and pass as before.