### PR TITLE
[Beto, James] upgrades com.ibm.icu:icu4j from version 59.1 to 60.1 to…

### DIFF
--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -14,7 +14,7 @@ public class Slugify {
 	private static final String BUILTIN_REPLACEMENTS_FILENAME = "replacements.properties";
 	private static final Properties REPLACEMENTS = new Properties();
 
-	private final static String ASCII = "Bulgarian-Latin/BGN; Any-Latin; Latin-ASCII; [^\\p{Print}] Remove; ['\"] Remove; Any-Lower";
+	private final static String ASCII = "Cyrillic-Latin; Any-Latin; Latin-ASCII; [^\\p{Print}] Remove; ['\"] Remove; Any-Lower";
 	private final static String EMPTY = "";
 
 	private final static Pattern PATTERN_NORMALIZE_NON_ASCII = Pattern.compile("[^\\p{ASCII}]+");

--- a/core/src/test/java/com/github/slugify/SlugifyTest.java
+++ b/core/src/test/java/com/github/slugify/SlugifyTest.java
@@ -2,9 +2,11 @@ package com.github.slugify;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.ibm.icu.text.Transliterator;
 import org.junit.Test;
 
 public class SlugifyTest {

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 			<dependency>
 				<groupId>com.ibm.icu</groupId>
 				<artifactId>icu4j</artifactId>
-				<version>59.1</version>
+				<version>60.1</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet.jsp</groupId>


### PR DESCRIPTION
Fixes issue #48 

This fixes known vulnerabilities in the com.ibm.icu:icu4j library. This also updates the encoding Bulgarian-latin/BGN to Cyrillic-Latin, for more details on this please refer to [ascii codes reference](https://www.ascii-codes.com/cp855.html)

(@jzimermann and I pairing)