### PR TITLE
Change Transliterator declaration to allow to exclude the dependency

### DIFF
--- a/core/src/main/java/com/github/slugify/Slugify.java
+++ b/core/src/main/java/com/github/slugify/Slugify.java
@@ -24,8 +24,6 @@ public class Slugify {
 	private final static Pattern PATTERN_NORMALIZE_UNDERSCORE_SEPARATOR = Pattern.compile("[[^a-zA-Z0-9\\-]\\s+]+");
 	private final static Pattern PATTERN_NORMALIZE_TRIM_DASH = Pattern.compile("^-|-$");
 
-	private static final Transliterator TRANSLITERATOR = Transliterator.getInstance(ASCII);
-
 	private final Map<String, String> customReplacements = new HashMap<String, String>();
 	private final Map<Character, String> builtinReplacements = new HashMap<Character, String>();
 
@@ -157,7 +155,7 @@ public class Slugify {
 	}
 
 	private String transliterate(final String input) {
-		String text = TRANSLITERATOR.transliterate(input);
+		String text = Transliterator.getInstance(ASCII).transliterate(input);
 		text = matchAndReplace(text);
 		return text;
 	}


### PR DESCRIPTION
Change Transliterator declaration to allow to exclude the dependency icu4j at pom if not used.
This dependency has more than 12MB and sometimes is not necessary.