### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,10 +13,7 @@
 	<name>Slugify - Core</name>
 
 	<dependencies>
-		<dependency>
-			<groupId>com.ibm.icu</groupId>
-			<artifactId>icu4j</artifactId>
-		</dependency>
+		
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/jstl/pom.xml
+++ b/jstl/pom.xml
@@ -21,15 +21,8 @@
 			<groupId>javax.servlet.jsp</groupId>
 			<artifactId>jsp-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
+		
+		
 	</dependencies>
 
 </project>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
slugify-parent
slugify
{groupId='com.ibm.icu', artifactId='icu4j'}
slugify-integration-jstl
{groupId='javax.servlet', artifactId='jstl'}
{groupId='junit', artifactId='junit'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
