### PR TITLE
add German capital ẞ and Icelandic ð, Ð, þ, Þ

### DIFF
--- a/src/main/resources/slugify_de.properties
+++ b/src/main/resources/slugify_de.properties
@@ -5,3 +5,4 @@
 \u00dc=Ue
 \u00fc=ue
 \u00df=ss
+\u1e9e=SS

--- a/src/main/resources/slugify_is.properties
+++ b/src/main/resources/slugify_is.properties
@@ -1,0 +1,4 @@
+\u00f0=d
+\u00d0=D
+\u00fe=th
+\u00de=Th

--- a/src/test/java/com/github/slugify/SlugifyTests.java
+++ b/src/test/java/com/github/slugify/SlugifyTests.java
@@ -108,7 +108,7 @@ class SlugifyTests {
 
   @SneakyThrows
   @ParameterizedTest
-  @ValueSource(strings = {"ar", "da", "de", "el", "no", "pl", "ru", "sv", "tr", "vi", "wa"})
+  @ValueSource(strings = {"ar", "da", "de", "el", "is", "no", "pl", "ru", "sv", "tr", "vi", "wa"})
   /* default */ void givenStringWhenStringContainsReplacementsThenSlugify(
       final String languageTag) {
     final Locale locale = Locale.forLanguageTag(languageTag);


### PR DESCRIPTION
replaces PR #71 

ẞ U+1E9E Latin capital letter sharp S
ð U+00F0 Latin small letter eth
Ð U+00D0 Latin capital letter Eth
þ U+00FE Latin small letter thorn
Þ U+00DE Latin capital letter Thorn