### PR TITLE
Update slugify_sv.properties fix äÄ öÖ unicodes

### DIFF
--- a/src/main/resources/slugify_sv.properties
+++ b/src/main/resources/slugify_sv.properties
@@ -1,6 +1,6 @@
 \u00e5=aa
 \u00c5=Aa
-\u00e6=ae
-\u00c6=Ae
-\u00f8=oe
-\u00d8=Oe
+\u00e4=ae
+\u00c4=Ae
+\u00f6=oe
+\u00d6=Oe


### PR DESCRIPTION
The old ones were Norwegian and should be Swedish.